### PR TITLE
ADD margin to the DTM map

### DIFF
--- a/lonestar/graphgrammar2/src/readers/SrtmReader.h
+++ b/lonestar/graphgrammar2/src/readers/SrtmReader.h
@@ -45,6 +45,7 @@ private:
 
 public:
   static const int VALUES_IN_DEGREE = 60 * 60 / RESOLUTION;
+  static const int MARGIN = 3;
 
   Map* read(const double west_border, const double north_border,
             const double east_border, const double south_border,


### PR DESCRIPTION
I think that this change could be nice. It also eases the computation of the height. We can discuss it.

Basically it does to things:

   - To ensure that numerical representation does not lead to problems
     when computing the height, we add some margins to the map, so all
     points are inside the DTM map

   - To this end, when converting the corners to ints, we add the
     margin, and then we convert again to the new corners that will be
     used in the map