### PR TITLE
Write the INP after each step

### DIFF
--- a/lonestar/graphgrammar2/src/GraphGrammar.cpp
+++ b/lonestar/graphgrammar2/src/GraphGrammar.cpp
@@ -189,10 +189,11 @@ int main(int argc, char** argv) {
             }
           },
           galois::loopname(("step" + std::to_string(j)).c_str()));
-          // Write the inp file
-          inpWriter("output_" + std::to_string(j) + ".inp", graph);
     }
     
+   // Write the inp file of step j
+   inpWriter("output_" + std::to_string(j) + ".inp", graph);
+
     step.stop();
     galois::gInfo("Step ", j, " finished.");
   }


### PR DESCRIPTION
   - Right now one step imply running more than once all productions.
     Maybe we should think in a better way to manage that.

   - As a consequence, the INP file was written more than once in one
     step (actually it was overwritten every time). It has been fixed so
     that it is written only once per step.